### PR TITLE
Update the furybsd-wifi-tool to follow best practices

### DIFF
--- a/bin/furybsd-wifi-tool
+++ b/bin/furybsd-wifi-tool
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bash
+#!/usr/bin/env bash
 
 # Only run as superuser
 if [ "$(id -u)" != "0" ]; then


### PR DESCRIPTION
It is considered best practice to use /usr/bin/env to resolve where the interpreter is over assuming where it is.